### PR TITLE
Upgrade ffmpeg to 4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@
 - Add ability to unset the 'interrupt' flag for a fmt context so you can stop it returning AVERROR_EXIT
 - Change avfilter.Context.SendCommand to return (string, error) so we can read the return data. User now sets the expected length and go allocates a buffer
 - Adds a packet.Copy method
+- Increment version to compile against 4.3
+- Add `avcodec.Packet.Write`, `avcodec.Packet.WriteBytes`, `avcodec.Packet.GetDataAt` methods
+- Add `avcodec.IOContext.Error` method

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -118,6 +118,9 @@ package avcodec
 //static uint8_t go_get_data_at(uint8_t *arr, int index) {
 //    return arr[index];
 //}
+//static void set_data_at(uint8_t *arr, int index, uint8_t data) {
+//	  arr[index] = data;
+//}
 //
 // int GO_AVCODEC_VERSION_MAJOR = LIBAVCODEC_VERSION_MAJOR;
 // int GO_AVCODEC_VERSION_MINOR = LIBAVCODEC_VERSION_MINOR;
@@ -448,6 +451,10 @@ func (pkt *Packet) GetData() []byte {
 		data[i] = byte(C.go_get_data_at((*C.uint8_t)(pkt.Data()), C.int(i)))
 	}
 	return data
+}
+
+func (pkt *Packet) GetDataAt(index int) byte {
+	return byte(C.go_get_data_at((*C.uint8_t)(pkt.Data()), C.int(index)))
 }
 
 func (pkt *Packet) SetData(data unsafe.Pointer) {

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -154,61 +154,62 @@ const (
 
 type Flags int
 
-// const (
-// 	FlagUnaligned     Flags = C.CODEC_FLAG_UNALIGNED
-// 	FlagQScale        Flags = C.CODEC_FLAG_QSCALE
-// 	Flag4MV           Flags = C.CODEC_FLAG_4MV
-// 	FlagOutputCorrupt Flags = C.CODEC_FLAG_OUTPUT_CORRUPT
-// 	FlagQPEL          Flags = C.CODEC_FLAG_QPEL
-// 	FlagPass1         Flags = C.CODEC_FLAG_PASS1
-// 	FlagPass2         Flags = C.CODEC_FLAG_PASS2
-// 	FlagGray          Flags = C.CODEC_FLAG_GRAY
-// 	FlagPSNR          Flags = C.CODEC_FLAG_PSNR
-// 	FlagTruncated     Flags = C.CODEC_FLAG_TRUNCATED
-// 	FlagInterlacedDCT Flags = C.CODEC_FLAG_INTERLACED_DCT
-// 	FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
-// 	FlagGlobalHeader  Flags = C.CODEC_FLAG_GLOBAL_HEADER
-// 	FlagBitExact      Flags = C.CODEC_FLAG_BITEXACT
-// 	FlagACPred        Flags = C.CODEC_FLAG_AC_PRED
-// 	FlagLoopFilter    Flags = C.CODEC_FLAG_LOOP_FILTER
-// 	FlagInterlacedME  Flags = C.CODEC_FLAG_INTERLACED_ME
-// 	FlagClosedGOP     Flags = C.CODEC_FLAG_CLOSED_GOP
-// )
+const (
+	FlagUnaligned Flags = C.AV_CODEC_FLAG_UNALIGNED
+
+	FlagQScale        Flags = C.AV_CODEC_FLAG_QSCALE
+	Flag4MV           Flags = C.AV_CODEC_FLAG_4MV
+	FlagOutputCorrupt Flags = C.AV_CODEC_FLAG_OUTPUT_CORRUPT
+	FlagQPEL          Flags = C.AV_CODEC_FLAG_QPEL
+	FlagPass1         Flags = C.AV_CODEC_FLAG_PASS1
+	FlagPass2         Flags = C.AV_CODEC_FLAG_PASS2
+	FlagGray          Flags = C.AV_CODEC_FLAG_GRAY
+	FlagPSNR          Flags = C.AV_CODEC_FLAG_PSNR
+	FlagTruncated     Flags = C.AV_CODEC_FLAG_TRUNCATED
+	FlagInterlacedDCT Flags = C.AV_CODEC_FLAG_INTERLACED_DCT
+	FlagLowDelay      Flags = C.AV_CODEC_FLAG_LOW_DELAY
+	FlagGlobalHeader  Flags = C.AV_CODEC_FLAG_GLOBAL_HEADER
+	FlagBitExact      Flags = C.AV_CODEC_FLAG_BITEXACT
+	FlagACPred        Flags = C.AV_CODEC_FLAG_AC_PRED
+	FlagLoopFilter    Flags = C.AV_CODEC_FLAG_LOOP_FILTER
+	FlagInterlacedME  Flags = C.AV_CODEC_FLAG_INTERLACED_ME
+	FlagClosedGOP     Flags = C.AV_CODEC_FLAG_CLOSED_GOP
+)
 
 type Flags2 int
 
-// const (
-// 	Flag2Fast              Flags2 = C.CODEC_FLAG2_FAST
-// 	Flag2NoOutput          Flags2 = C.CODEC_FLAG2_NO_OUTPUT
-// 	Flag2LocalHeader       Flags2 = C.CODEC_FLAG2_LOCAL_HEADER
-// 	Flag2DropFrameTimecode Flags2 = C.CODEC_FLAG2_DROP_FRAME_TIMECODE
-// 	Flag2IgnoreCrop        Flags2 = C.CODEC_FLAG2_IGNORE_CROP
-// 	Flag2Chunks            Flags2 = C.CODEC_FLAG2_CHUNKS
-// 	Flag2ShowAll           Flags2 = C.CODEC_FLAG2_SHOW_ALL
-// 	Flag2ExportMvs         Flags2 = C.CODEC_FLAG2_EXPORT_MVS
-// 	Flag2SkipManual        Flags2 = C.CODEC_FLAG2_SKIP_MANUAL
-// )
+const (
+	Flag2Fast              Flags2 = C.AV_CODEC_FLAG2_FAST
+	Flag2NoOutput          Flags2 = C.AV_CODEC_FLAG2_NO_OUTPUT
+	Flag2LocalHeader       Flags2 = C.AV_CODEC_FLAG2_LOCAL_HEADER
+	Flag2DropFrameTimecode Flags2 = C.AV_CODEC_FLAG2_DROP_FRAME_TIMECODE
+	Flag2IgnoreCrop        Flags2 = C.AV_CODEC_FLAG2_IGNORE_CROP
+	Flag2Chunks            Flags2 = C.AV_CODEC_FLAG2_CHUNKS
+	Flag2ShowAll           Flags2 = C.AV_CODEC_FLAG2_SHOW_ALL
+	Flag2ExportMvs         Flags2 = C.AV_CODEC_FLAG2_EXPORT_MVS
+	Flag2SkipManual        Flags2 = C.AV_CODEC_FLAG2_SKIP_MANUAL
+)
 
 type Capabilities int
 
 const (
-	// CapabilityDrawHorizBand     Capabilities = C.CODEC_CAP_DRAW_HORIZ_BAND
-	// CapabilityDR1               Capabilities = C.CODEC_CAP_DR1
-	// CapabilityTruncated         Capabilities = C.CODEC_CAP_TRUNCATED
-	CapabilityHWAccel Capabilities = C.GO_CODEC_CAP_HWACCEL
-	// CapabilityDelay             Capabilities = C.CODEC_CAP_DELAY
-	// CapabilitySmallLastFrame    Capabilities = C.CODEC_CAP_SMALL_LAST_FRAME
-	CapabilityHWAccelVDPAU Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
-	// CapabilitySubframes         Capabilities = C.CODEC_CAP_SUBFRAMES
-	// CapabilityExperimental      Capabilities = C.CODEC_CAP_EXPERIMENTAL
-	// CapabilityChannelConf       Capabilities = C.CODEC_CAP_CHANNEL_CONF
-	// CapabilityFrameThreads      Capabilities = C.CODEC_CAP_FRAME_THREADS
-	// CapabilitySliceThreads      Capabilities = C.CODEC_CAP_SLICE_THREADS
-	// CapabilityParamChange       Capabilities = C.CODEC_CAP_PARAM_CHANGE
-	// CapabilityAutoThreads       Capabilities = C.CODEC_CAP_AUTO_THREADS
-	// CapabilityVariableFrameSize Capabilities = C.CODEC_CAP_VARIABLE_FRAME_SIZE
-	// CapabilityIntraOnly         Capabilities = C.CODEC_CAP_INTRA_ONLY
-	// CapabilityLossless          Capabilities = C.CODEC_CAP_LOSSLESS
+	CapabilityDrawHorizBand     Capabilities = C.AV_CODEC_CAP_DRAW_HORIZ_BAND
+	CapabilityDR1               Capabilities = C.AV_CODEC_CAP_DR1
+	CapabilityTruncated         Capabilities = C.AV_CODEC_CAP_TRUNCATED
+	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
+	CapabilityDelay             Capabilities = C.AV_CODEC_CAP_DELAY
+	CapabilitySmallLastFrame    Capabilities = C.AV_CODEC_CAP_SMALL_LAST_FRAME
+	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
+	CapabilitySubframes         Capabilities = C.AV_CODEC_CAP_SUBFRAMES
+	CapabilityExperimental      Capabilities = C.AV_CODEC_CAP_EXPERIMENTAL
+	CapabilityChannelConf       Capabilities = C.AV_CODEC_CAP_CHANNEL_CONF
+	CapabilityFrameThreads      Capabilities = C.AV_CODEC_CAP_FRAME_THREADS
+	CapabilitySliceThreads      Capabilities = C.AV_CODEC_CAP_SLICE_THREADS
+	CapabilityParamChange       Capabilities = C.AV_CODEC_CAP_PARAM_CHANGE
+	CapabilityAutoThreads       Capabilities = C.AV_CODEC_CAP_AUTO_THREADS
+	CapabilityVariableFrameSize Capabilities = C.AV_CODEC_CAP_VARIABLE_FRAME_SIZE
+	CapabilityIntraOnly         Capabilities = C.AV_CODEC_CAP_INTRA_ONLY
+	CapabilityLossless          Capabilities = C.AV_CODEC_CAP_LOSSLESS
 )
 
 type Compliance int

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -107,9 +107,6 @@ package avcodec
 //static uint8_t go_get_data_at(uint8_t *arr, int index) {
 //    return arr[index];
 //}
-//static void set_data_at(uint8_t *arr, int index, uint8_t data) {
-//	  arr[index] = data;
-//}
 //
 // int GO_AVCODEC_VERSION_MAJOR = LIBAVCODEC_VERSION_MAJOR;
 // int GO_AVCODEC_VERSION_MINOR = LIBAVCODEC_VERSION_MINOR;
@@ -405,9 +402,9 @@ func (pkt *Packet) SetBytes(b []byte) error {
 			return avutil.NewErrorFromCode(avutil.ErrorCode(ret))
 		}
 	}
-	for i := 0; i < len(b); i++ {
-		C.set_data_at(pkt.CAVPacket.data, C.int(i), (C.uint8_t)(b[i]))
-	}
+	buf := C.CBytes(b)
+	C.memcpy(unsafe.Pointer(pkt.CAVPacket.data), buf, C.ulong(len(b)))
+	C.free(buf)
 	pkt.CAVPacket.size = size
 	return nil
 }

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -3,17 +3,6 @@ package avcodec
 //#include <libavutil/avutil.h>
 //#include <libavcodec/avcodec.h>
 //
-//#ifdef CODEC_CAP_HWACCEL
-//#define GO_CODEC_CAP_HWACCEL CODEC_CAP_HWACCEL
-//#else
-//#define GO_CODEC_CAP_HWACCEL 0
-//#endif
-//
-//#ifdef CODEC_CAP_HWACCEL_VDPAU
-//#define GO_CODEC_CAP_HWACCEL_VDPAU CODEC_CAP_HWACCEL_VDPAU
-//#else
-//#define GO_CODEC_CAP_HWACCEL_VDPAU 0
-//#endif
 //
 //#ifdef FF_DCT_INT
 //#define GO_FF_DCT_INT FF_DCT_INT

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -152,66 +152,6 @@ const (
 	CodecIDLJpeg CodecID = C.AV_CODEC_ID_LJPEG
 )
 
-type Flags int
-
-const (
-	FlagUnaligned Flags = C.AV_CODEC_FLAG_UNALIGNED
-
-	FlagQScale        Flags = C.AV_CODEC_FLAG_QSCALE
-	Flag4MV           Flags = C.AV_CODEC_FLAG_4MV
-	FlagOutputCorrupt Flags = C.AV_CODEC_FLAG_OUTPUT_CORRUPT
-	FlagQPEL          Flags = C.AV_CODEC_FLAG_QPEL
-	FlagPass1         Flags = C.AV_CODEC_FLAG_PASS1
-	FlagPass2         Flags = C.AV_CODEC_FLAG_PASS2
-	FlagGray          Flags = C.AV_CODEC_FLAG_GRAY
-	FlagPSNR          Flags = C.AV_CODEC_FLAG_PSNR
-	FlagTruncated     Flags = C.AV_CODEC_FLAG_TRUNCATED
-	FlagInterlacedDCT Flags = C.AV_CODEC_FLAG_INTERLACED_DCT
-	FlagLowDelay      Flags = C.AV_CODEC_FLAG_LOW_DELAY
-	FlagGlobalHeader  Flags = C.AV_CODEC_FLAG_GLOBAL_HEADER
-	FlagBitExact      Flags = C.AV_CODEC_FLAG_BITEXACT
-	FlagACPred        Flags = C.AV_CODEC_FLAG_AC_PRED
-	FlagLoopFilter    Flags = C.AV_CODEC_FLAG_LOOP_FILTER
-	FlagInterlacedME  Flags = C.AV_CODEC_FLAG_INTERLACED_ME
-	FlagClosedGOP     Flags = C.AV_CODEC_FLAG_CLOSED_GOP
-)
-
-type Flags2 int
-
-const (
-	Flag2Fast              Flags2 = C.AV_CODEC_FLAG2_FAST
-	Flag2NoOutput          Flags2 = C.AV_CODEC_FLAG2_NO_OUTPUT
-	Flag2LocalHeader       Flags2 = C.AV_CODEC_FLAG2_LOCAL_HEADER
-	Flag2DropFrameTimecode Flags2 = C.AV_CODEC_FLAG2_DROP_FRAME_TIMECODE
-	Flag2IgnoreCrop        Flags2 = C.AV_CODEC_FLAG2_IGNORE_CROP
-	Flag2Chunks            Flags2 = C.AV_CODEC_FLAG2_CHUNKS
-	Flag2ShowAll           Flags2 = C.AV_CODEC_FLAG2_SHOW_ALL
-	Flag2ExportMvs         Flags2 = C.AV_CODEC_FLAG2_EXPORT_MVS
-	Flag2SkipManual        Flags2 = C.AV_CODEC_FLAG2_SKIP_MANUAL
-)
-
-type Capabilities int
-
-const (
-	CapabilityDrawHorizBand     Capabilities = C.AV_CODEC_CAP_DRAW_HORIZ_BAND
-	CapabilityDR1               Capabilities = C.AV_CODEC_CAP_DR1
-	CapabilityTruncated         Capabilities = C.AV_CODEC_CAP_TRUNCATED
-	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
-	CapabilityDelay             Capabilities = C.AV_CODEC_CAP_DELAY
-	CapabilitySmallLastFrame    Capabilities = C.AV_CODEC_CAP_SMALL_LAST_FRAME
-	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
-	CapabilitySubframes         Capabilities = C.AV_CODEC_CAP_SUBFRAMES
-	CapabilityExperimental      Capabilities = C.AV_CODEC_CAP_EXPERIMENTAL
-	CapabilityChannelConf       Capabilities = C.AV_CODEC_CAP_CHANNEL_CONF
-	CapabilityFrameThreads      Capabilities = C.AV_CODEC_CAP_FRAME_THREADS
-	CapabilitySliceThreads      Capabilities = C.AV_CODEC_CAP_SLICE_THREADS
-	CapabilityParamChange       Capabilities = C.AV_CODEC_CAP_PARAM_CHANGE
-	CapabilityAutoThreads       Capabilities = C.AV_CODEC_CAP_AUTO_THREADS
-	CapabilityVariableFrameSize Capabilities = C.AV_CODEC_CAP_VARIABLE_FRAME_SIZE
-	CapabilityIntraOnly         Capabilities = C.AV_CODEC_CAP_INTRA_ONLY
-	CapabilityLossless          Capabilities = C.AV_CODEC_CAP_LOSSLESS
-)
-
 type Compliance int
 
 const (

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -151,61 +151,61 @@ const (
 
 type Flags int
 
-const (
-	FlagUnaligned     Flags = C.CODEC_FLAG_UNALIGNED
-	FlagQScale        Flags = C.CODEC_FLAG_QSCALE
-	Flag4MV           Flags = C.CODEC_FLAG_4MV
-	FlagOutputCorrupt Flags = C.CODEC_FLAG_OUTPUT_CORRUPT
-	FlagQPEL          Flags = C.CODEC_FLAG_QPEL
-	FlagPass1         Flags = C.CODEC_FLAG_PASS1
-	FlagPass2         Flags = C.CODEC_FLAG_PASS2
-	FlagGray          Flags = C.CODEC_FLAG_GRAY
-	FlagPSNR          Flags = C.CODEC_FLAG_PSNR
-	FlagTruncated     Flags = C.CODEC_FLAG_TRUNCATED
-	FlagInterlacedDCT Flags = C.CODEC_FLAG_INTERLACED_DCT
-	FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
-	FlagGlobalHeader  Flags = C.CODEC_FLAG_GLOBAL_HEADER
-	FlagBitExact      Flags = C.CODEC_FLAG_BITEXACT
-	FlagACPred        Flags = C.CODEC_FLAG_AC_PRED
-	FlagLoopFilter    Flags = C.CODEC_FLAG_LOOP_FILTER
-	FlagInterlacedME  Flags = C.CODEC_FLAG_INTERLACED_ME
-	FlagClosedGOP     Flags = C.CODEC_FLAG_CLOSED_GOP
-)
+// const (
+// 	FlagUnaligned     Flags = C.CODEC_FLAG_UNALIGNED
+// 	FlagQScale        Flags = C.CODEC_FLAG_QSCALE
+// 	Flag4MV           Flags = C.CODEC_FLAG_4MV
+// 	FlagOutputCorrupt Flags = C.CODEC_FLAG_OUTPUT_CORRUPT
+// 	FlagQPEL          Flags = C.CODEC_FLAG_QPEL
+// 	FlagPass1         Flags = C.CODEC_FLAG_PASS1
+// 	FlagPass2         Flags = C.CODEC_FLAG_PASS2
+// 	FlagGray          Flags = C.CODEC_FLAG_GRAY
+// 	FlagPSNR          Flags = C.CODEC_FLAG_PSNR
+// 	FlagTruncated     Flags = C.CODEC_FLAG_TRUNCATED
+// 	FlagInterlacedDCT Flags = C.CODEC_FLAG_INTERLACED_DCT
+// 	FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
+// 	FlagGlobalHeader  Flags = C.CODEC_FLAG_GLOBAL_HEADER
+// 	FlagBitExact      Flags = C.CODEC_FLAG_BITEXACT
+// 	FlagACPred        Flags = C.CODEC_FLAG_AC_PRED
+// 	FlagLoopFilter    Flags = C.CODEC_FLAG_LOOP_FILTER
+// 	FlagInterlacedME  Flags = C.CODEC_FLAG_INTERLACED_ME
+// 	FlagClosedGOP     Flags = C.CODEC_FLAG_CLOSED_GOP
+// )
 
 type Flags2 int
 
-const (
-	Flag2Fast              Flags2 = C.CODEC_FLAG2_FAST
-	Flag2NoOutput          Flags2 = C.CODEC_FLAG2_NO_OUTPUT
-	Flag2LocalHeader       Flags2 = C.CODEC_FLAG2_LOCAL_HEADER
-	Flag2DropFrameTimecode Flags2 = C.CODEC_FLAG2_DROP_FRAME_TIMECODE
-	Flag2IgnoreCrop        Flags2 = C.CODEC_FLAG2_IGNORE_CROP
-	Flag2Chunks            Flags2 = C.CODEC_FLAG2_CHUNKS
-	Flag2ShowAll           Flags2 = C.CODEC_FLAG2_SHOW_ALL
-	Flag2ExportMvs         Flags2 = C.CODEC_FLAG2_EXPORT_MVS
-	Flag2SkipManual        Flags2 = C.CODEC_FLAG2_SKIP_MANUAL
-)
+// const (
+// 	Flag2Fast              Flags2 = C.CODEC_FLAG2_FAST
+// 	Flag2NoOutput          Flags2 = C.CODEC_FLAG2_NO_OUTPUT
+// 	Flag2LocalHeader       Flags2 = C.CODEC_FLAG2_LOCAL_HEADER
+// 	Flag2DropFrameTimecode Flags2 = C.CODEC_FLAG2_DROP_FRAME_TIMECODE
+// 	Flag2IgnoreCrop        Flags2 = C.CODEC_FLAG2_IGNORE_CROP
+// 	Flag2Chunks            Flags2 = C.CODEC_FLAG2_CHUNKS
+// 	Flag2ShowAll           Flags2 = C.CODEC_FLAG2_SHOW_ALL
+// 	Flag2ExportMvs         Flags2 = C.CODEC_FLAG2_EXPORT_MVS
+// 	Flag2SkipManual        Flags2 = C.CODEC_FLAG2_SKIP_MANUAL
+// )
 
 type Capabilities int
 
 const (
-	CapabilityDrawHorizBand     Capabilities = C.CODEC_CAP_DRAW_HORIZ_BAND
-	CapabilityDR1               Capabilities = C.CODEC_CAP_DR1
-	CapabilityTruncated         Capabilities = C.CODEC_CAP_TRUNCATED
-	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
-	CapabilityDelay             Capabilities = C.CODEC_CAP_DELAY
-	CapabilitySmallLastFrame    Capabilities = C.CODEC_CAP_SMALL_LAST_FRAME
-	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
-	CapabilitySubframes         Capabilities = C.CODEC_CAP_SUBFRAMES
-	CapabilityExperimental      Capabilities = C.CODEC_CAP_EXPERIMENTAL
-	CapabilityChannelConf       Capabilities = C.CODEC_CAP_CHANNEL_CONF
-	CapabilityFrameThreads      Capabilities = C.CODEC_CAP_FRAME_THREADS
-	CapabilitySliceThreads      Capabilities = C.CODEC_CAP_SLICE_THREADS
-	CapabilityParamChange       Capabilities = C.CODEC_CAP_PARAM_CHANGE
-	CapabilityAutoThreads       Capabilities = C.CODEC_CAP_AUTO_THREADS
-	CapabilityVariableFrameSize Capabilities = C.CODEC_CAP_VARIABLE_FRAME_SIZE
-	CapabilityIntraOnly         Capabilities = C.CODEC_CAP_INTRA_ONLY
-	CapabilityLossless          Capabilities = C.CODEC_CAP_LOSSLESS
+	// CapabilityDrawHorizBand     Capabilities = C.CODEC_CAP_DRAW_HORIZ_BAND
+	// CapabilityDR1               Capabilities = C.CODEC_CAP_DR1
+	// CapabilityTruncated         Capabilities = C.CODEC_CAP_TRUNCATED
+	CapabilityHWAccel Capabilities = C.GO_CODEC_CAP_HWACCEL
+	// CapabilityDelay             Capabilities = C.CODEC_CAP_DELAY
+	// CapabilitySmallLastFrame    Capabilities = C.CODEC_CAP_SMALL_LAST_FRAME
+	CapabilityHWAccelVDPAU Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
+	// CapabilitySubframes         Capabilities = C.CODEC_CAP_SUBFRAMES
+	// CapabilityExperimental      Capabilities = C.CODEC_CAP_EXPERIMENTAL
+	// CapabilityChannelConf       Capabilities = C.CODEC_CAP_CHANNEL_CONF
+	// CapabilityFrameThreads      Capabilities = C.CODEC_CAP_FRAME_THREADS
+	// CapabilitySliceThreads      Capabilities = C.CODEC_CAP_SLICE_THREADS
+	// CapabilityParamChange       Capabilities = C.CODEC_CAP_PARAM_CHANGE
+	// CapabilityAutoThreads       Capabilities = C.CODEC_CAP_AUTO_THREADS
+	// CapabilityVariableFrameSize Capabilities = C.CODEC_CAP_VARIABLE_FRAME_SIZE
+	// CapabilityIntraOnly         Capabilities = C.CODEC_CAP_INTRA_ONLY
+	// CapabilityLossless          Capabilities = C.CODEC_CAP_LOSSLESS
 )
 
 type Compliance int
@@ -452,6 +452,27 @@ func (pkt *Packet) GetData() []byte {
 
 func (pkt *Packet) SetData(data unsafe.Pointer) {
 	pkt.CAVPacket.data = (*C.uint8_t)(data)
+}
+
+func (pkt *Packet) SetBytes(b []byte) error {
+	size := C.int(len(b))
+	if pkt.CAVPacket.data == nil {
+		ret := C.av_new_packet(pkt.CAVPacket, C.int(len(b)))
+		if ret < 0 {
+			return avutil.NewErrorFromCode(avutil.ErrorCode(ret))
+		}
+	}
+	if pkt.CAVPacket.size < size {
+		ret := C.av_grow_packet(pkt.CAVPacket, size-pkt.CAVPacket.size)
+		if ret < 0 {
+			return avutil.NewErrorFromCode(avutil.ErrorCode(ret))
+		}
+	}
+	for i := 0; i < len(b); i++ {
+		C.set_data_at(pkt.CAVPacket.data, C.int(i), (C.uint8_t)(b[i]))
+	}
+	pkt.CAVPacket.size = size
+	return nil
 }
 
 func (pkt *Packet) Size() int {

--- a/avcodec/avcodec43.go
+++ b/avcodec/avcodec43.go
@@ -2,12 +2,24 @@
 
 package avcodec
 
-import "C"
-
 //#include <libavutil/avutil.h>
 //#include <libavcodec/avcodec.h>
 //
+//#ifdef CODEC_CAP_HWACCEL
+//#define GO_CODEC_CAP_HWACCEL CODEC_CAP_HWACCEL
+//#else
+//#define GO_CODEC_CAP_HWACCEL 0
+//#endif
+//
+//#ifdef CODEC_CAP_HWACCEL_VDPAU
+//#define GO_CODEC_CAP_HWACCEL_VDPAU CODEC_CAP_HWACCEL_VDPAU
+//#else
+//#define GO_CODEC_CAP_HWACCEL_VDPAU 0
+//#endif
+//
 // #cgo LDFLAGS: -lavcodec -lavutil
+import "C"
+
 type Flags int
 
 const (

--- a/avcodec/avcodec43.go
+++ b/avcodec/avcodec43.go
@@ -1,0 +1,69 @@
+// +build ffmpeg43
+
+package avcodec
+
+import "C"
+
+//#include <libavutil/avutil.h>
+//#include <libavcodec/avcodec.h>
+//
+// #cgo LDFLAGS: -lavcodec -lavutil
+type Flags int
+
+const (
+	FlagUnaligned Flags = C.AV_CODEC_FLAG_UNALIGNED
+
+	FlagQScale        Flags = C.AV_CODEC_FLAG_QSCALE
+	Flag4MV           Flags = C.AV_CODEC_FLAG_4MV
+	FlagOutputCorrupt Flags = C.AV_CODEC_FLAG_OUTPUT_CORRUPT
+	FlagQPEL          Flags = C.AV_CODEC_FLAG_QPEL
+	FlagPass1         Flags = C.AV_CODEC_FLAG_PASS1
+	FlagPass2         Flags = C.AV_CODEC_FLAG_PASS2
+	FlagGray          Flags = C.AV_CODEC_FLAG_GRAY
+	FlagPSNR          Flags = C.AV_CODEC_FLAG_PSNR
+	FlagTruncated     Flags = C.AV_CODEC_FLAG_TRUNCATED
+	FlagInterlacedDCT Flags = C.AV_CODEC_FLAG_INTERLACED_DCT
+	FlagLowDelay      Flags = C.AV_CODEC_FLAG_LOW_DELAY
+	FlagGlobalHeader  Flags = C.AV_CODEC_FLAG_GLOBAL_HEADER
+	FlagBitExact      Flags = C.AV_CODEC_FLAG_BITEXACT
+	FlagACPred        Flags = C.AV_CODEC_FLAG_AC_PRED
+	FlagLoopFilter    Flags = C.AV_CODEC_FLAG_LOOP_FILTER
+	FlagInterlacedME  Flags = C.AV_CODEC_FLAG_INTERLACED_ME
+	FlagClosedGOP     Flags = C.AV_CODEC_FLAG_CLOSED_GOP
+)
+
+type Flags2 int
+
+const (
+	Flag2Fast              Flags2 = C.AV_CODEC_FLAG2_FAST
+	Flag2NoOutput          Flags2 = C.AV_CODEC_FLAG2_NO_OUTPUT
+	Flag2LocalHeader       Flags2 = C.AV_CODEC_FLAG2_LOCAL_HEADER
+	Flag2DropFrameTimecode Flags2 = C.AV_CODEC_FLAG2_DROP_FRAME_TIMECODE
+	Flag2IgnoreCrop        Flags2 = C.AV_CODEC_FLAG2_IGNORE_CROP
+	Flag2Chunks            Flags2 = C.AV_CODEC_FLAG2_CHUNKS
+	Flag2ShowAll           Flags2 = C.AV_CODEC_FLAG2_SHOW_ALL
+	Flag2ExportMvs         Flags2 = C.AV_CODEC_FLAG2_EXPORT_MVS
+	Flag2SkipManual        Flags2 = C.AV_CODEC_FLAG2_SKIP_MANUAL
+)
+
+type Capabilities int
+
+const (
+	CapabilityDrawHorizBand     Capabilities = C.AV_CODEC_CAP_DRAW_HORIZ_BAND
+	CapabilityDR1               Capabilities = C.AV_CODEC_CAP_DR1
+	CapabilityTruncated         Capabilities = C.AV_CODEC_CAP_TRUNCATED
+	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
+	CapabilityDelay             Capabilities = C.AV_CODEC_CAP_DELAY
+	CapabilitySmallLastFrame    Capabilities = C.AV_CODEC_CAP_SMALL_LAST_FRAME
+	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
+	CapabilitySubframes         Capabilities = C.AV_CODEC_CAP_SUBFRAMES
+	CapabilityExperimental      Capabilities = C.AV_CODEC_CAP_EXPERIMENTAL
+	CapabilityChannelConf       Capabilities = C.AV_CODEC_CAP_CHANNEL_CONF
+	CapabilityFrameThreads      Capabilities = C.AV_CODEC_CAP_FRAME_THREADS
+	CapabilitySliceThreads      Capabilities = C.AV_CODEC_CAP_SLICE_THREADS
+	CapabilityParamChange       Capabilities = C.AV_CODEC_CAP_PARAM_CHANGE
+	CapabilityAutoThreads       Capabilities = C.AV_CODEC_CAP_AUTO_THREADS
+	CapabilityVariableFrameSize Capabilities = C.AV_CODEC_CAP_VARIABLE_FRAME_SIZE
+	CapabilityIntraOnly         Capabilities = C.AV_CODEC_CAP_INTRA_ONLY
+	CapabilityLossless          Capabilities = C.AV_CODEC_CAP_LOSSLESS
+)

--- a/avcodec/flags.go
+++ b/avcodec/flags.go
@@ -1,0 +1,81 @@
+// +build !ffmpeg43
+
+package avcodec
+
+//#include <libavutil/avutil.h>
+//#include <libavcodec/avcodec.h>
+//
+//
+//#ifdef CODEC_CAP_HWACCEL
+//#define GO_CODEC_CAP_HWACCEL CODEC_CAP_HWACCEL
+//#else
+//#define GO_CODEC_CAP_HWACCEL 0
+//#endif
+//
+//#ifdef CODEC_CAP_HWACCEL_VDPAU
+//#define GO_CODEC_CAP_HWACCEL_VDPAU CODEC_CAP_HWACCEL_VDPAU
+//#else
+//#define GO_CODEC_CAP_HWACCEL_VDPAU 0
+//#endif
+//
+// #cgo LDFLAGS: -lavcodec -lavutil
+import "C"
+
+type Flags int
+
+const (
+	FlagUnaligned     Flags = C.CODEC_FLAG_UNALIGNED
+	FlagQScale        Flags = C.CODEC_FLAG_QSCALE
+	Flag4MV           Flags = C.CODEC_FLAG_4MV
+	FlagOutputCorrupt Flags = C.CODEC_FLAG_OUTPUT_CORRUPT
+	FlagQPEL          Flags = C.CODEC_FLAG_QPEL
+	FlagPass1         Flags = C.CODEC_FLAG_PASS1
+	FlagPass2         Flags = C.CODEC_FLAG_PASS2
+	FlagGray          Flags = C.CODEC_FLAG_GRAY
+	FlagPSNR          Flags = C.CODEC_FLAG_PSNR
+	FlagTruncated     Flags = C.CODEC_FLAG_TRUNCATED
+	FlagInterlacedDCT Flags = C.CODEC_FLAG_INTERLACED_DCT
+	FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
+	FlagGlobalHeader  Flags = C.CODEC_FLAG_GLOBAL_HEADER
+	FlagBitExact      Flags = C.CODEC_FLAG_BITEXACT
+	FlagACPred        Flags = C.CODEC_FLAG_AC_PRED
+	FlagLoopFilter    Flags = C.CODEC_FLAG_LOOP_FILTER
+	FlagInterlacedME  Flags = C.CODEC_FLAG_INTERLACED_ME
+	FlagClosedGOP     Flags = C.CODEC_FLAG_CLOSED_GOP
+)
+
+type Flags2 int
+
+const (
+	Flag2Fast              Flags2 = C.CODEC_FLAG2_FAST
+	Flag2NoOutput          Flags2 = C.CODEC_FLAG2_NO_OUTPUT
+	Flag2LocalHeader       Flags2 = C.CODEC_FLAG2_LOCAL_HEADER
+	Flag2DropFrameTimecode Flags2 = C.CODEC_FLAG2_DROP_FRAME_TIMECODE
+	Flag2IgnoreCrop        Flags2 = C.CODEC_FLAG2_IGNORE_CROP
+	Flag2Chunks            Flags2 = C.CODEC_FLAG2_CHUNKS
+	Flag2ShowAll           Flags2 = C.CODEC_FLAG2_SHOW_ALL
+	Flag2ExportMvs         Flags2 = C.CODEC_FLAG2_EXPORT_MVS
+	Flag2SkipManual        Flags2 = C.CODEC_FLAG2_SKIP_MANUAL
+)
+
+type Capabilities int
+
+const (
+	CapabilityDrawHorizBand     Capabilities = C.CODEC_CAP_DRAW_HORIZ_BAND
+	CapabilityDR1               Capabilities = C.CODEC_CAP_DR1
+	CapabilityTruncated         Capabilities = C.CODEC_CAP_TRUNCATED
+	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
+	CapabilityDelay             Capabilities = C.CODEC_CAP_DELAY
+	CapabilitySmallLastFrame    Capabilities = C.CODEC_CAP_SMALL_LAST_FRAME
+	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
+	CapabilitySubframes         Capabilities = C.CODEC_CAP_SUBFRAMES
+	CapabilityExperimental      Capabilities = C.CODEC_CAP_EXPERIMENTAL
+	CapabilityChannelConf       Capabilities = C.CODEC_CAP_CHANNEL_CONF
+	CapabilityFrameThreads      Capabilities = C.CODEC_CAP_FRAME_THREADS
+	CapabilitySliceThreads      Capabilities = C.CODEC_CAP_SLICE_THREADS
+	CapabilityParamChange       Capabilities = C.CODEC_CAP_PARAM_CHANGE
+	CapabilityAutoThreads       Capabilities = C.CODEC_CAP_AUTO_THREADS
+	CapabilityVariableFrameSize Capabilities = C.CODEC_CAP_VARIABLE_FRAME_SIZE
+	CapabilityIntraOnly         Capabilities = C.CODEC_CAP_INTRA_ONLY
+	CapabilityLossless          Capabilities = C.CODEC_CAP_LOSSLESS
+)

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -4,6 +4,7 @@ package avformat
 //#include <libavutil/avstring.h>
 //#include <libavcodec/avcodec.h>
 //#include <libavformat/avformat.h>
+//#include <stdlib.h>
 //
 //#ifdef AVFMT_FLAG_FAST_SEEK
 //#define GO_AVFMT_FLAG_FAST_SEEK AVFMT_FLAG_FAST_SEEK
@@ -45,9 +46,6 @@ package avformat
 // void set_interrupt_cb(AVFormatContext *c) {
 //	  c->interrupt_callback.callback = interrupt_cb;
 //	  c->interrupt_callback.opaque = 0;
-//}
-// void write_at(unsigned char * buf, unsigned long i, unsigned char b) {
-//	  buf[i] = b;
 //}
 //
 //
@@ -1028,13 +1026,9 @@ func (ctx *IOContext) Write(packet unsafe.Pointer, size int) {
 }
 
 func (ctx *IOContext) WriteBytes(b []byte) {
-	size := C.ulong(len(b))
-	buf := C.av_mallocz(size)
-	for i := C.ulong(0); i < size; i++ {
-		C.write_at((*C.uchar)(buf), i, C.uchar(b[i]))
-	}
+	buf := C.CBytes(b)
 	ctx.Write(buf, len(b))
-	C.av_free(buf)
+	C.free(buf)
 }
 
 func (ctx *IOContext) Error() error {

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -84,10 +84,9 @@ func (ctx *Context) SetInterruptCallback() {
 type Flags int
 
 const (
-	FlagNoFile     Flags = C.AVFMT_NOFILE
-	FlagNeedNumber Flags = C.AVFMT_NEEDNUMBER
-	FlagShowIDs    Flags = C.AVFMT_SHOW_IDS
-	// FlagRawPicture   Flags = C.AVFMT_RAWPICTURE
+	FlagNoFile       Flags = C.AVFMT_NOFILE
+	FlagNeedNumber   Flags = C.AVFMT_NEEDNUMBER
+	FlagShowIDs      Flags = C.AVFMT_SHOW_IDS
 	FlagGlobalHeader Flags = C.AVFMT_GLOBALHEADER
 	FlagNoTimestamps Flags = C.AVFMT_NOTIMESTAMPS
 	FlagGenericIndex Flags = C.AVFMT_GENERIC_INDEX

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -81,10 +81,10 @@ func (ctx *Context) SetInterruptCallback() {
 type Flags int
 
 const (
-	FlagNoFile       Flags = C.AVFMT_NOFILE
-	FlagNeedNumber   Flags = C.AVFMT_NEEDNUMBER
-	FlagShowIDs      Flags = C.AVFMT_SHOW_IDS
-	FlagRawPicture   Flags = C.AVFMT_RAWPICTURE
+	FlagNoFile     Flags = C.AVFMT_NOFILE
+	FlagNeedNumber Flags = C.AVFMT_NEEDNUMBER
+	FlagShowIDs    Flags = C.AVFMT_SHOW_IDS
+	// FlagRawPicture   Flags = C.AVFMT_RAWPICTURE
 	FlagGlobalHeader Flags = C.AVFMT_GLOBALHEADER
 	FlagNoTimestamps Flags = C.AVFMT_NOTIMESTAMPS
 	FlagGenericIndex Flags = C.AVFMT_GENERIC_INDEX


### PR DESCRIPTION
~Is a breaking change so will require all go-libav apps (ATM I think it is only synchroniser) to compile against version 4.~

I have updated to ensure the current builds still run, so can be safely merged before the synchroniser upgrade PR is merged.