### PR TITLE
Misc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@
 - Increment version to compile against 4.3
 - Add `avcodec.Packet.Write`, `avcodec.Packet.WriteBytes`, `avcodec.Packet.GetDataAt` methods
 - Add `avcodec.IOContext.Error` method
+- Add `avcodec.IOContext.Flush` method
+- Use go builtin to get go byte array from C
+- Add `avcodec.Packet.GetDataInto` to get data into an existing go byte array
+- Make `avcodec.Packet.Free` a noop on a nil packet (aligns with libav convention)

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -1039,6 +1039,10 @@ func (ctx *IOContext) Error() error {
 	return nil
 }
 
+func (ctx *IOContext) Flush() {
+	C.avio_flush(ctx.CAVIOContext)
+}
+
 func boolToCInt(b bool) C.int {
 	if b {
 		return 1


### PR DESCRIPTION
- Add `avcodec.IOContext.Flush` method
- Use go builtin to get go byte array from C
- Add `avcodec.Packet.GetDataInto` to get data into an existing go byte array
- Make `avcodec.Packet.Free` a noop on a nil packet (aligns with libav convention)