### PR TITLE
Fix memory leak in FIFO SendCommand code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Make `avcodec.Packet.Free` a noop on a nil packet (aligns with libav convention)
 - Add `GetDataUnsafe` method to Packet, which returns a Go slice which directly references the underlying C array representing the data of the packet
 - Nil check CAVFormatContext before using InterruptBlockingOperation as it can be called before it is set up properly
+- Fix memory leak in FIFO SendCommand code

--- a/avcodec/avcodec43.go
+++ b/avcodec/avcodec43.go
@@ -1,3 +1,4 @@
+//go:build ffmpeg43
 // +build ffmpeg43
 
 package avcodec

--- a/avcodec/flags.go
+++ b/avcodec/flags.go
@@ -1,3 +1,4 @@
+//go:build !ffmpeg43
 // +build !ffmpeg43
 
 package avcodec

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -405,7 +405,9 @@ func (ctx *Context) FrameRate() *avutil.Rational {
 
 func (ctx *Context) SendCommand(cmd, args string, returnLength int) (string, error) {
 	cmdString := C.CString(cmd)
+	defer C.free(unsafe.Pointer(cmdString))
 	argsString := C.CString(args)
+	defer C.free(unsafe.Pointer(argsString))
 	var res *C.char
 	var res_len C.int
 	if returnLength > 0 {
@@ -415,6 +417,7 @@ func (ctx *Context) SendCommand(cmd, args string, returnLength int) (string, err
 			str.WriteString("a")
 		}
 		res = C.CString(str.String())
+		defer C.free(unsafe.Pointer(res))
 		res_len = C.int(returnLength)
 	}
 	code := C.avfilter_process_command(ctx.CAVFilterContext, cmdString, argsString, res, res_len, C.int(0))


### PR DESCRIPTION
We forgot to free the strings we create, when sending commands to the FIFOs! This frees them, and probably fixes the biggest memory leak in synchroniser.