### PR TITLE
Don't store go-lang stack variables in native heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - Nil check CAVFormatContext before using InterruptBlockingOperation as it can be called before it is set up properly
 - Fix memory leak in FIFO SendCommand code
 - Add go-mod
+- Don't store go-lang stack variables in native heap


### PR DESCRIPTION
Some experiments with running:
```
CGO_CFLAGS="-fsanitize=address"
CGO_LDFLAGS="-L/usr/local/lib -Wl,-rpath,/usr/local/lib -fsanitize=address"
GOEXPERIMENT="cgocheck2"
```

Explodes dramatically on this line:
```
ctx.CAVFormatContext.interrupt_callback.opaque = unsafe.Pointer(&data)
```

This is because `data` is stored in the go-lang stack. We are taking an unsafe pointer to this data in the stack, and passing it to native code. Go typically frees memory on the stack quickly, and is also allowed to move it around arbitrarily.


I have implemented a fix as manually allocating and free-ing memory for this pointer, solves the issue.