### PR TITLE
Fix interrupt callback not propagating to URLContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - Don't store go-lang stack variables in native heap
 - Add Get/SetInt64OptionC functions
 - Add GetFrameFlags to avfilter
+- Fix interrupt callback: set opaque pointer before avformat_open_input so URLContext copy inherits it

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -611,7 +611,9 @@ func NewContextFromC(cCtx unsafe.Pointer) *Context {
 		CAVFormatContext: (*C.AVFormatContext)(cCtx),
 		interruptPtr:     (*C.int)(C.malloc(C.sizeof_int)),
 	}
+	*ctx.interruptPtr = 0
 	ctx.SetInterruptCallback()
+	ctx.CAVFormatContext.interrupt_callback.opaque = unsafe.Pointer(ctx.interruptPtr)
 	return &ctx
 }
 
@@ -975,6 +977,9 @@ func (ctx *Context) InterruptBlockingOperation() {
 		return
 	}
 	*ctx.interruptPtr = 1
+	// Also set opaque here as a safety net, though it should already be set
+	// since NewContextFromC. The critical path is that opaque is set BEFORE
+	// avformat_open_input, so the URLContext's struct-copy gets the pointer.
 	ctx.CAVFormatContext.interrupt_callback.opaque = unsafe.Pointer(ctx.interruptPtr)
 }
 


### PR DESCRIPTION
## Summary
- Fix broken interrupt callback that prevented InterruptBlockingOperation() from interrupting blocking I/O (av_read_frame, etc.)
- Root cause: opaque pointer was NULL when FFmpeg struct-copied the callback into the URLContext at open time
- Set opaque = interruptPtr in NewContextFromC so the URLContext copy inherits the correct pointer

## Test plan
- [ ] Verify synchroniser's TestLibavTsRaw_DieOnNRTSIP passes with this fix (previously hung for 27+ minutes)
- [ ] Run synchroniser integration tests with updated go-libav

🤖 Generated with [Claude Code](https://claude.com/claude-code)