### PR TITLE
Panic on libav allocation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@
 - Add GetFrameFlags to avfilter
 - Fix interrupt callback: set opaque pointer before avformat_open_input so URLContext copy inherits it
 - Replace deprecated FFmpeg 4.3 APIs and remove the now-empty avcodec/avformat/avfilter RegisterAll wrappers
+- Panic on libav allocation failures

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -280,19 +280,16 @@ type Packet struct {
 	CAVPacket *C.AVPacket
 }
 
-func NewPacket() (*Packet, error) {
+func NewPacket() *Packet {
 	cPkt := (*C.AVPacket)(C.av_packet_alloc())
 	if cPkt == nil {
-		return nil, ErrAllocationError
+		panic("av_packet_alloc: out of memory")
 	}
-	return NewPacketFromC(unsafe.Pointer(cPkt)), nil
+	return NewPacketFromC(unsafe.Pointer(cPkt))
 }
 
 func (pkt *Packet) Copy() (*Packet, error) {
-	newpacket, err := NewPacket()
-	if err != nil {
-		return newpacket, err
-	}
+	newpacket := NewPacket()
 	C.av_init_packet(newpacket.CAVPacket)
 	code := C.av_packet_ref(newpacket.CAVPacket, pkt.CAVPacket)
 	if code < 0 {
@@ -672,16 +669,16 @@ type Context struct {
 	*avutil.OptionAccessor
 }
 
-func NewContextWithCodec(codec *Codec) (*Context, error) {
+func NewContextWithCodec(codec *Codec) *Context {
 	var cCodec *C.AVCodec
 	if codec != nil {
 		cCodec = codec.CAVCodec
 	}
 	cCtx := C.avcodec_alloc_context3(cCodec)
 	if cCtx == nil {
-		return nil, ErrAllocationError
+		panic("avcodec_alloc_context3: out of memory")
 	}
-	return NewContextFromC(unsafe.Pointer(cCtx)), nil
+	return NewContextFromC(unsafe.Pointer(cCtx))
 }
 
 func NewContextFromC(cCtx unsafe.Pointer) *Context {
@@ -1842,22 +1839,19 @@ func (ctx *Context) StatsIn() []byte {
 	return (*[1 << 30]byte)(unsafe.Pointer(ctx.CAVCodecContext.stats_in))[:length:length]
 }
 
-func (ctx *Context) SetStatsIn(in []byte) error {
+func (ctx *Context) SetStatsIn(in []byte) {
 	C.av_freep(unsafe.Pointer(&ctx.CAVCodecContext.stats_in))
 	if len(in) == 0 {
-		return nil
+		return
 	}
 	length := len(in)
 	cIn := (*C.char)(C.av_malloc(C.size_t(length + 1)))
 	if cIn == nil {
-		return ErrAllocationError
+		panic("av_malloc: out of memory")
 	}
-	if len(in) > 0 {
-		C.memcpy(unsafe.Pointer(cIn), unsafe.Pointer(&in[0]), C.size_t(length))
-	}
+	C.memcpy(unsafe.Pointer(cIn), unsafe.Pointer(&in[0]), C.size_t(length))
 	C.memset(unsafe.Pointer(uintptr(unsafe.Pointer(cIn))+uintptr(length)), 0, 1)
 	ctx.CAVCodecContext.stats_in = cIn
-	return nil
 }
 
 func (ctx *Context) StatsOut() []byte {
@@ -1868,22 +1862,19 @@ func (ctx *Context) StatsOut() []byte {
 	return (*[1 << 30]byte)(unsafe.Pointer(ctx.CAVCodecContext.stats_out))[:length:length]
 }
 
-func (ctx *Context) SetStatsOut(out []byte) error {
+func (ctx *Context) SetStatsOut(out []byte) {
 	C.av_freep(unsafe.Pointer(&ctx.CAVCodecContext.stats_out))
 	if len(out) == 0 {
-		return nil
+		return
 	}
 	length := len(out)
 	cOut := (*C.char)(C.av_malloc(C.size_t(length + 1)))
 	if cOut == nil {
-		return ErrAllocationError
+		panic("av_malloc: out of memory")
 	}
-	if len(out) > 0 {
-		C.memcpy(unsafe.Pointer(cOut), unsafe.Pointer(&out[0]), C.size_t(length))
-	}
+	C.memcpy(unsafe.Pointer(cOut), unsafe.Pointer(&out[0]), C.size_t(length))
 	C.memset(unsafe.Pointer(uintptr(unsafe.Pointer(cOut))+uintptr(length)), 0, 1)
 	ctx.CAVCodecContext.stats_out = cOut
-	return nil
 }
 
 func cStringToStringOk(cStr *C.char) (string, bool) {

--- a/avcodec/avcodec30.go
+++ b/avcodec/avcodec30.go
@@ -1,3 +1,4 @@
+//go:build ffmpeg30
 // +build ffmpeg30
 
 package avcodec
@@ -132,21 +133,20 @@ func (ctx *BitStreamFilterContext) ArgsOK() (string, bool) {
 	return cStringToStringOk(ctx.CAVBitStreamFilterContext.args)
 }
 
-func (ctx *BitStreamFilterContext) SetArgs(args *string) error {
+func (ctx *BitStreamFilterContext) SetArgs(args *string) {
 	C.av_freep(unsafe.Pointer(&ctx.CAVBitStreamFilterContext.args))
 	if args == nil {
-		return nil
+		return
 	}
 	bArgs := []byte(*args)
 	length := len(bArgs)
 	cArgs := (*C.char)(C.av_malloc(C.size_t(length + 1)))
 	if cArgs == nil {
-		return ErrAllocationError
+		panic("av_malloc: out of memory")
 	}
 	if length > 0 {
 		C.memcpy(unsafe.Pointer(cArgs), unsafe.Pointer(&bArgs[0]), C.size_t(length))
 	}
 	C.memset(unsafe.Pointer(uintptr(unsafe.Pointer(cArgs))+uintptr(length)), 0, 1)
 	ctx.CAVBitStreamFilterContext.args = cArgs
-	return nil
 }

--- a/avcodec/avcodec30_test.go
+++ b/avcodec/avcodec30_test.go
@@ -1,3 +1,4 @@
+//go:build ffmpeg30
 // +build ffmpeg30
 
 package avcodec
@@ -67,9 +68,7 @@ func TestBitStreamFilterContext_Args(t *testing.T) {
 	}
 
 	input := avutil.String("argstest")
-	if err := ctx.SetArgs(input); err != nil {
-		t.Fatalf("[TestBitStreamFilterContext_Args] err=%v, NG expected not error", err)
-	}
+	ctx.SetArgs(input)
 	_, ok = ctx.ArgsOK()
 	if !ok {
 		t.Fatalf("[TestBitStreamFilterContext_Args] ok=%t, NG expected=%t", ok, true)
@@ -79,9 +78,7 @@ func TestBitStreamFilterContext_Args(t *testing.T) {
 		t.Fatalf("[TestBitStreamFilterContext_Args] result=%s, NG expected=%s", result, *input)
 	}
 
-	if err := ctx.SetArgs(nil); err != nil {
-		t.Fatalf("[TestBitStreamFilterContext_Args] err=%v, NG expected not error", err)
-	}
+	ctx.SetArgs(nil)
 	_, ok = ctx.ArgsOK()
 	if ok {
 		t.Fatalf("[TestBitStreamFilterContext_Args] ok=%t, NG expected=%t", ok, false)

--- a/avcodec/avcodec33.go
+++ b/avcodec/avcodec33.go
@@ -26,12 +26,12 @@ type CodecParameters struct {
 	CAVCodecParameters *C.AVCodecParameters
 }
 
-func NewCodecParameters() (*CodecParameters, error) {
+func NewCodecParameters() *CodecParameters {
 	cPkt := (*C.AVCodecParameters)(C.avcodec_parameters_alloc())
 	if cPkt == nil {
-		return nil, ErrAllocationError
+		panic("avcodec_parameters_alloc: out of memory")
 	}
-	return NewCodecParametersFromC(unsafe.Pointer(cPkt)), nil
+	return NewCodecParametersFromC(unsafe.Pointer(cPkt))
 }
 
 func NewCodecParametersFromC(cPSD unsafe.Pointer) *CodecParameters {
@@ -44,10 +44,7 @@ func (cParams *CodecParameters) Free() {
 
 func (ctx *Context) CopyTo(dst *Context) error {
 	// added in lavc 57.33.100
-	parameters, err := NewCodecParameters()
-	if err != nil {
-		return err
-	}
+	parameters := NewCodecParameters()
 	defer parameters.Free()
 	cParams := (*C.AVCodecParameters)(unsafe.Pointer(parameters.CAVCodecParameters))
 	code := C.avcodec_parameters_from_context(cParams, ctx.CAVCodecContext)

--- a/avcodec/avcodec_test.go
+++ b/avcodec/avcodec_test.go
@@ -31,10 +31,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestNewPacket(t *testing.T) {
-	pkt, err := NewPacket()
-	if err != nil {
-		t.Fatal(err)
-	}
+	pkt := NewPacket()
 	defer pkt.Free()
 	if pkt == nil {
 		t.Fatalf("Expecting packet")
@@ -42,7 +39,7 @@ func TestNewPacket(t *testing.T) {
 }
 
 func TestPacketFree(t *testing.T) {
-	pkt, _ := NewPacket()
+	pkt := NewPacket()
 	if pkt.CAVPacket == nil {
 		t.Fatalf("Expecting packet")
 	}
@@ -55,7 +52,7 @@ func TestPacketFree(t *testing.T) {
 }
 
 func TestPacketDuration(t *testing.T) {
-	pkt, _ := NewPacket()
+	pkt := NewPacket()
 	defer pkt.Free()
 	data := int64(100000)
 	pkt.SetDuration(data)
@@ -67,10 +64,7 @@ func TestPacketDuration(t *testing.T) {
 func TestPacketNewFreeLeak10M(t *testing.T) {
 	before := testMemoryUsed(t)
 	for i := 0; i < 10000000; i++ {
-		pkt, err := NewPacket()
-		if err != nil {
-			t.Fatal(err)
-		}
+		pkt := NewPacket()
 		pkt.Free()
 	}
 	testMemoryLeak(t, before, 50*1024*1024)
@@ -205,55 +199,40 @@ func TestContextStatInOutOK(t *testing.T) {
 	if codec == nil {
 		t.Error("error")
 	}
-	ctx, err := NewContextWithCodec(codec)
-	if err != nil {
-		t.Error("error")
-	}
+	ctx = NewContextWithCodec(codec)
 	defer ctx.Free()
 
 	expected := []byte("stats_in")
-	if err := ctx.SetStatsIn(expected); err != nil {
-		t.Fatalf("[TestContextStatInOutOK] err=%v NG, expected is not error", err)
-	}
+	ctx.SetStatsIn(expected)
 	result := ctx.StatsIn()
 	if !bytes.Equal(result, expected) {
 		t.Fatalf("[TestContextStatInOutOK] result=%s NG, expected=%s", result, expected)
 	}
 	expected = []byte{}
-	if err := ctx.SetStatsIn(expected); err != nil {
-		t.Fatalf("[TestContextStatInOutOK] err=%v NG, expected is not error", err)
-	}
+	ctx.SetStatsIn(expected)
 	result = ctx.StatsIn()
 	if !bytes.Equal(result, expected) {
 		t.Fatalf("[TestContextStatInOutOK] result=%v NG, expected=%v", result, expected)
 	}
-	if err := ctx.SetStatsIn(nil); err != nil {
-		t.Fatalf("[TestContextStatInOutOK] err=%v NG, expected is not error", err)
-	}
+	ctx.SetStatsIn(nil)
 	result = ctx.StatsIn()
 	if result != nil {
 		t.Fatalf("[TestContextStatInOutOK] result=%v NG, expected=nil", result)
 	}
 
 	expected = []byte("stats_out")
-	if err := ctx.SetStatsOut(expected); err != nil {
-		t.Fatalf("[TestContextStatInOutOK] err=%v NG, expected is not error", err)
-	}
+	ctx.SetStatsOut(expected)
 	result = ctx.StatsOut()
 	if !bytes.Equal(result, expected) {
 		t.Fatalf("[TestContextStatInOutOK] result=%s NG, expected=%s", result, expected)
 	}
 	expected = []byte{}
-	if err := ctx.SetStatsOut(expected); err != nil {
-		t.Fatalf("[TestContextStatInOutOK] err=%v NG, expected is not error", err)
-	}
+	ctx.SetStatsOut(expected)
 	result = ctx.StatsOut()
 	if !bytes.Equal(result, expected) {
 		t.Fatalf("[TestContextStatInOutOK] result=%v NG, expected=%v", result, expected)
 	}
-	if err := ctx.SetStatsOut(nil); err != nil {
-		t.Fatalf("[TestContextStatInOutOK] err=%v NG, expected is not error", err)
-	}
+	ctx.SetStatsOut(nil)
 	result = ctx.StatsOut()
 	if result != nil {
 		t.Fatalf("[TestContextStatInOutOK] result=%v NG, expected=nil", result)
@@ -369,10 +348,7 @@ func testNewContextWithCodec(t *testing.T, name string) *Context {
 	if codec == nil {
 		t.Fatalf("Expecting codec")
 	}
-	ctx, err := NewContextWithCodec(codec)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := NewContextWithCodec(codec)
 	if ctx == nil {
 		t.Fatalf("Expecting context")
 	}
@@ -380,10 +356,7 @@ func testNewContextWithCodec(t *testing.T, name string) *Context {
 }
 
 func TestNewContextWithCodecNil(t *testing.T) {
-	ctx, err := NewContextWithCodec(nil)
-	if err != nil {
-		t.Fatalf("Expecting allocate")
-	}
+	ctx := NewContextWithCodec(nil)
 	if ctx == nil {
 		t.Fatalf("Expecting context")
 	}
@@ -449,12 +422,11 @@ func findPixelFormatByName(name string, t *testing.T) avutil.PixelFormat {
 }
 
 func BenchmarkAVPacketGetData(b *testing.B) {
-	pkt, err := NewPacket()
+	pkt := NewPacket()
 	randBytes := make([]byte, 188)
-	_, err = rand.Read(randBytes)
+	_, err := rand.Read(randBytes)
 	require.NoError(b, err)
 	pkt.SetBytes(randBytes)
-	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		//Op
 		pkt.GetData()
@@ -463,12 +435,11 @@ func BenchmarkAVPacketGetData(b *testing.B) {
 }
 
 func BenchmarkAVPacketGetDataAt(b *testing.B) {
-	pkt, err := NewPacket()
+	pkt := NewPacket()
 	randBytes := make([]byte, 188)
-	_, err = rand.Read(randBytes)
+	_, err := rand.Read(randBytes)
 	require.NoError(b, err)
 	pkt.SetBytes(randBytes)
-	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		//Op
 		pkt.GetDataAt(1)

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -446,12 +446,12 @@ type Graph struct {
 	CAVFilterGraph *C.AVFilterGraph
 }
 
-func NewGraph() (*Graph, error) {
+func NewGraph() *Graph {
 	cGraph := C.avfilter_graph_alloc()
 	if cGraph == nil {
-		return nil, ErrAllocationError
+		panic("avfilter_graph_alloc: out of memory")
 	}
-	return NewGraphFromC(unsafe.Pointer(cGraph)), nil
+	return NewGraphFromC(unsafe.Pointer(cGraph))
 }
 
 func NewGraphFromC(cGraph unsafe.Pointer) *Graph {
@@ -513,24 +513,24 @@ func (g *Graph) RequestOldest() error {
 	return nil
 }
 
-func (g *Graph) Dump() (string, error) {
+func (g *Graph) Dump() string {
 	cStr := C.avfilter_graph_dump(g.CAVFilterGraph, nil)
 	if cStr == nil {
-		return "", ErrAllocationError
+		panic("avfilter_graph_dump: out of memory")
 	}
 	defer C.av_free(unsafe.Pointer(cStr))
-	return C.GoString(cStr), nil
+	return C.GoString(cStr)
 }
 
-func (g *Graph) DumpWithOptions(options string) (string, error) {
+func (g *Graph) DumpWithOptions(options string) string {
 	cOptions := C.CString(options)
 	defer C.free(unsafe.Pointer(cOptions))
 	cStr := C.avfilter_graph_dump(g.CAVFilterGraph, cOptions)
 	if cStr == nil {
-		return "", ErrAllocationError
+		panic("avfilter_graph_dump: out of memory")
 	}
 	defer C.av_free(unsafe.Pointer(cStr))
-	return C.GoString(cStr), nil
+	return C.GoString(cStr)
 }
 
 func (g *Graph) AutoConvertFlags() GraphAutoConvertFlags {
@@ -545,12 +545,12 @@ type InOut struct {
 	CAVFilterInOut *C.AVFilterInOut
 }
 
-func NewInOut() (*InOut, error) {
+func NewInOut() *InOut {
 	cInOut := C.avfilter_inout_alloc()
 	if cInOut == nil {
-		return nil, ErrAllocationError
+		panic("avfilter_inout_alloc: out of memory")
 	}
-	return NewInOutFromC(unsafe.Pointer(cInOut)), nil
+	return NewInOutFromC(unsafe.Pointer(cInOut))
 }
 
 func NewInOutFromC(cInOut unsafe.Pointer) *InOut {
@@ -572,13 +572,12 @@ func (io *InOut) NameOk() (string, bool) {
 	return cStringToStringOk(io.CAVFilterInOut.name)
 }
 
-func (io *InOut) SetName(name string) error {
+func (io *InOut) SetName(name string) {
 	C.free(unsafe.Pointer(io.CAVFilterInOut.name))
 	io.CAVFilterInOut.name = C.CString(name)
 	if io.CAVFilterInOut.name == nil {
-		return ErrAllocationError
+		panic("CString: out of memory")
 	}
-	return nil
 }
 
 func (io *InOut) PadIndex() int {

--- a/avfilter/avfilter_test.go
+++ b/avfilter/avfilter_test.go
@@ -141,10 +141,7 @@ func testGraphAddFilter(t *testing.T, graph *Graph, name, id string) *Context {
 }
 
 func testNewGraph(t *testing.T) *Graph {
-	graph, err := NewGraph()
-	if err != nil {
-		t.Fatal(err)
-	}
+	graph := NewGraph()
 	if graph == nil {
 		t.Fatalf("Expecting filter graph")
 	}
@@ -154,10 +151,7 @@ func testNewGraph(t *testing.T) *Graph {
 func TestInOutNewFreeLeak10M(t *testing.T) {
 	before := testMemoryUsed(t)
 	for i := 0; i < 10000000; i++ {
-		io, err := NewInOut()
-		if err != nil {
-			t.Fatal(err)
-		}
+		io := NewInOut()
 		io.Free()
 	}
 	testMemoryLeak(t, before, 50*1024*1024)

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -283,27 +283,26 @@ func (pd *ProbeData) Free() {
 	pd.CAVProbeData.mime_type = nil
 }
 
-func (pd *ProbeData) SetFileName(fileName *string) error {
+func (pd *ProbeData) SetFileName(fileName *string) {
 	C.free(unsafe.Pointer(pd.CAVProbeData.filename))
 	if fileName == nil {
 		pd.CAVProbeData.filename = nil
-		return nil
+		return
 	}
 	pd.CAVProbeData.filename = C.CString(*fileName)
 	if pd.CAVProbeData.filename == nil {
-		return ErrAllocationError
+		panic("CString: out of memory")
 	}
-	return nil
 }
 
-func (pd *ProbeData) SetBuffer(buffer []byte) error {
+func (pd *ProbeData) SetBuffer(buffer []byte) {
 	pd.CAVProbeData.buf_size = 0
 	C.av_freep(unsafe.Pointer(&pd.CAVProbeData.buf))
 	size := C.size_t(len(buffer))
 	extraSize := C.size_t(C.AVPROBE_PADDING_SIZE)
 	buf := C.av_malloc(size + extraSize)
 	if buf == nil {
-		return ErrAllocationError
+		panic("av_malloc: out of memory")
 	}
 	if size != 0 {
 		C.memcpy(buf, unsafe.Pointer(&buffer[0]), size)
@@ -311,20 +310,18 @@ func (pd *ProbeData) SetBuffer(buffer []byte) error {
 	C.memset(unsafe.Pointer(uintptr(buf)+uintptr(size)), 0, extraSize)
 	pd.CAVProbeData.buf = (*C.uchar)(buf)
 	pd.CAVProbeData.buf_size = C.int(size)
-	return nil
 }
 
-func (pd *ProbeData) SetMimeType(mimeType *string) error {
+func (pd *ProbeData) SetMimeType(mimeType *string) {
 	C.free(unsafe.Pointer(pd.CAVProbeData.mime_type))
 	if mimeType == nil {
 		pd.CAVProbeData.mime_type = nil
-		return nil
+		return
 	}
 	pd.CAVProbeData.mime_type = C.CString(*mimeType)
 	if pd.CAVProbeData.mime_type == nil {
-		return ErrAllocationError
+		panic("CString: out of memory")
 	}
-	return nil
 }
 
 func ProbeInput(pd *ProbeData, isOpened bool) *Input {
@@ -585,12 +582,12 @@ type Context struct {
 	interruptPtr     *C.int
 }
 
-func NewContextForInput() (*Context, error) {
+func NewContextForInput() *Context {
 	cCtx := C.avformat_alloc_context()
 	if cCtx == nil {
-		return nil, ErrAllocationError
+		panic("avformat_alloc_context: out of memory")
 	}
-	return NewContextFromC(unsafe.Pointer(cCtx)), nil
+	return NewContextFromC(unsafe.Pointer(cCtx))
 }
 
 func NewContextForOutput(output *Output) (*Context, error) {
@@ -702,10 +699,7 @@ func (ctx *Context) WriteTrailer() error {
 }
 
 func (ctx *Context) ReadFrame() (*avcodec.Packet, error) {
-	pkt, err := avcodec.NewPacket()
-	if err != nil {
-		return nil, err
-	}
+	pkt := avcodec.NewPacket()
 	cPkt := (*C.AVPacket)(unsafe.Pointer(pkt.CAVPacket))
 	code := C.av_read_frame(ctx.CAVFormatContext, cPkt)
 	if code < 0 {

--- a/avformat/avformat_test.go
+++ b/avformat/avformat_test.go
@@ -62,7 +62,7 @@ func TestFindInputByShortName(t *testing.T) {
 }
 
 func TestInputFlags(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	fixture := fixturePath("sample_mpeg4.mp4")
 	err := ctx.OpenInput(fixture, nil, nil)
@@ -85,9 +85,7 @@ func TestProbeDataSetBuffer(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := pd.SetBuffer(b); err != nil {
-			t.Fatal(err)
-		}
+		pd.SetBuffer(b)
 		if pd.CAVProbeData.buf == nil {
 			t.Fatalf("Expecting buf")
 		}
@@ -271,8 +269,8 @@ func TestGuessOutputFromMimeType(t *testing.T) {
 }
 
 func TestNewContextForInput(t *testing.T) {
-	ctx, err := NewContextForInput()
-	if err != nil || ctx == nil {
+	ctx := NewContextForInput()
+	if ctx == nil {
 		t.Fatalf("Expecting context")
 	}
 	defer ctx.Free()
@@ -291,7 +289,7 @@ func TestNewContextForOutput(t *testing.T) {
 }
 
 func TestContextOpenInputNonExistent(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	err := ctx.OpenInput("foobarnonexistent", nil, nil).(*avutil.Error)
 	if err == nil {
@@ -304,7 +302,7 @@ func TestContextOpenInputNonExistent(t *testing.T) {
 }
 
 func TestContextOpenInputExistent(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	fixture := fixturePath("sample_mpeg4.mp4")
 	err := ctx.OpenInput(fixture, nil, nil)
@@ -315,7 +313,7 @@ func TestContextOpenInputExistent(t *testing.T) {
 }
 
 func TestContextOpenInputWithOptions(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	fixture := fixturePath("sample_mpeg4.mp4")
 
@@ -352,7 +350,7 @@ func fixturePath(elem ...string) string {
 }
 
 func TestSetFileName(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 
 	var buff bytes.Buffer
@@ -373,7 +371,7 @@ func TestSetFileName(t *testing.T) {
 }
 
 func TestContextSeekToTimestamp(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	fixture := fixturePath("sample_mpeg4.mp4")
 	err := ctx.OpenInput(fixture, nil, nil)
@@ -387,7 +385,7 @@ func TestContextSeekToTimestamp(t *testing.T) {
 }
 
 func TestSampleAspectRatio(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	stream, err := ctx.NewStream()
 	if err != nil {
@@ -403,7 +401,7 @@ func TestSampleAspectRatio(t *testing.T) {
 }
 
 func TestRealFrameRate(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	stream, err := ctx.NewStream()
 	if err != nil {
@@ -419,7 +417,7 @@ func TestRealFrameRate(t *testing.T) {
 }
 
 func TestStreamFirstDTSOK(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	stream, err := ctx.NewStream()
 	if err != nil {
@@ -465,7 +463,7 @@ func TestStreamEndPTSOK(t *testing.T) {
 }
 
 func testOpenInput(t *testing.T) *Context {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	if err := ctx.OpenInput(fixturePath("sample_mpeg4.mp4"), nil, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -505,10 +503,7 @@ func testWritePacket(t *testing.T, iCtx *Context, oCtx *Context) *avcodec.Packet
 }
 
 func testNewPacket(t *testing.T) *avcodec.Packet {
-	pkt, err := avcodec.NewPacket()
-	if err != nil {
-		t.Fatal(err)
-	}
+	pkt := avcodec.NewPacket()
 	if pkt == nil {
 		t.Fatalf("Expecting packet")
 	}
@@ -516,7 +511,7 @@ func testNewPacket(t *testing.T) *avcodec.Packet {
 }
 
 func TestGuessFrameRate(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 
 	fixture := fixturePath("sample_mpeg4.mp4")
@@ -544,7 +539,7 @@ func TestGuessFrameRate(t *testing.T) {
 }
 
 func TestContextDuration(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 
 	ctx.SetDuration(1000000)
@@ -555,7 +550,7 @@ func TestContextDuration(t *testing.T) {
 }
 
 func TestContextMaxDelay(t *testing.T) {
-	ctx, _ := NewContextForInput()
+	ctx := NewContextForInput()
 	defer ctx.Free()
 
 	ctx.SetMaxDelay(500000)
@@ -566,10 +561,7 @@ func TestContextMaxDelay(t *testing.T) {
 }
 
 func TestContextMetaData(t *testing.T) {
-	fmtCtx, err := NewContextForInput()
-	if err != nil {
-		t.Fatal(err)
-	}
+	fmtCtx := NewContextForInput()
 	defer fmtCtx.Free()
 	metadata := fmtCtx.MetaData()
 	if count := metadata.Count(); count != 0 {
@@ -608,10 +600,7 @@ func TestContextMetaData(t *testing.T) {
 }
 
 func TestContextSetMetaData(t *testing.T) {
-	fmtCtx, err := NewContextForInput()
-	if err != nil {
-		t.Fatal(err)
-	}
+	fmtCtx := NewContextForInput()
 	defer fmtCtx.Free()
 	if count := fmtCtx.MetaData().Count(); count != 0 {
 		t.Fatalf("Expecting count but got %d", count)
@@ -627,10 +616,7 @@ func TestContextSetMetaData(t *testing.T) {
 }
 
 func TestContext_IOOpenCallback(t *testing.T) {
-	ctx, err := NewContextForInput()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	cb := ctx.IOOpenCallback()
 	if cb == nil {
@@ -652,10 +638,7 @@ func TestContext_IOOpenCallback(t *testing.T) {
 }
 
 func TestContext_IOCloseCallback(t *testing.T) {
-	ctx, err := NewContextForInput()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx := NewContextForInput()
 	defer ctx.Free()
 	cb := ctx.IOCloseCallback()
 	if cb == nil {
@@ -679,10 +662,7 @@ func TestContext_IOCloseCallback(t *testing.T) {
 func TestContextNewFreeLeak1M(t *testing.T) {
 	before := testMemoryUsed(t)
 	for i := 0; i < 1000000; i++ {
-		ctx, err := NewContextForInput()
-		if err != nil {
-			t.Fatal(err)
-		}
+		ctx := NewContextForInput()
 		ctx.Free()
 	}
 	testMemoryLeak(t, before, 50*1024*1024)
@@ -786,10 +766,7 @@ func ExampleShowMediaInfo() {
 	inputFileName := fixturePath("sample_iPod.m4v")
 
 	// open format (container) context
-	decFmt, err := NewContextForInput()
-	if err != nil {
-		log.Fatalf("Failed to open input context: %v. Run 'make fixture' to fetch the required files", err)
-	}
+	decFmt := NewContextForInput()
 
 	// set some options for opening file
 	options := avutil.NewDictionary()

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -761,12 +761,12 @@ type Frame struct {
 	CAVFrame *C.AVFrame
 }
 
-func NewFrame() (*Frame, error) {
+func NewFrame() *Frame {
 	cFrame := C.av_frame_alloc()
 	if cFrame == nil {
-		return nil, ErrAllocationError
+		panic("av_frame_alloc: out of memory")
 	}
-	return NewFrameFromC(unsafe.Pointer(cFrame)), nil
+	return NewFrameFromC(unsafe.Pointer(cFrame))
 }
 
 func NewFrameFromC(cFrame unsafe.Pointer) *Frame {
@@ -1543,7 +1543,7 @@ func NewAudioFifo(sf SampleFormat, layout ChannelLayout, nb_samples int) (*Audio
 	cSampleFormat := C.av_get_sample_fmt(cName)
 	cAudioFifo := C.av_audio_fifo_alloc(cSampleFormat, C.int(layout.NumberOfChannels()), C.int(nb_samples))
 	if cAudioFifo == nil {
-		return nil, ErrAllocationError
+		panic("av_audio_fifo_alloc: out of memory")
 	}
 	fifo := NewAudioFifoFromC(unsafe.Pointer(cAudioFifo))
 	fifo.SampleFmt = sf

--- a/avutil/avutil_test.go
+++ b/avutil/avutil_test.go
@@ -553,10 +553,7 @@ func TestFindPixelFormatByName(t *testing.T) {
 }
 
 func TestNewFrame(t *testing.T) {
-	frame, err := NewFrame()
-	if err != nil {
-		t.Fatal(err)
-	}
+	frame := NewFrame()
 	if frame == nil {
 		t.Fatalf("Expecting frame")
 	}
@@ -564,7 +561,7 @@ func TestNewFrame(t *testing.T) {
 }
 
 func TestFramePacketDurationOK(t *testing.T) {
-	frame, _ := NewFrame()
+	frame := NewFrame()
 	defer frame.Free()
 	result := frame.PacketDuration()
 	if result != 0 {
@@ -573,7 +570,7 @@ func TestFramePacketDurationOK(t *testing.T) {
 }
 
 func TestFrameGetBuffer(t *testing.T) {
-	frame, _ := NewFrame()
+	frame := NewFrame()
 	defer frame.Free()
 	if frame.Data(0) != nil {
 		t.Fatalf("Expecting no data")
@@ -593,16 +590,13 @@ func TestFrameGetBuffer(t *testing.T) {
 
 func TestFrameNewFreeLeak10M(t *testing.T) {
 	for i := 0; i < 10000000; i++ {
-		frame, err := NewFrame()
-		if err != nil {
-			t.Fatal(err)
-		}
+		frame := NewFrame()
 		frame.Free()
 	}
 }
 
 func TestFrameMetadata(t *testing.T) {
-	frame, _ := NewFrame()
+	frame := NewFrame()
 	defer frame.Free()
 
 	result := frame.Metadata()


### PR DESCRIPTION
## Summary

Convert the alloc-only error paths in `go-libav` to panic on NULL. These wrappers around FFmpeg allocators (`av_packet_alloc`, `av_frame_alloc`, `av_malloc`, `C.CString`, etc.) returned `ErrAllocationError` for paths whose only failure mode is OOM. On modern 64-bit systems with overcommit + OOM killer, a `malloc` NULL is effectively unrecoverable, so the wrapper errors were dead weight spread across every consumer.

Each affected call site was cross-referenced against the C source in `spalk-ffmpeg` (FFmpeg 4.3.1 fork) to confirm OOM is the only failure mode before the error return was dropped.

### Signature changes

- `avcodec.NewPacket`, `NewContextWithCodec`, `NewCodecParameters`
- `avcodec.Context.SetStatsIn`, `SetStatsOut`
- `avcodec.BitStreamFilterContext.SetArgs` (ffmpeg30)
- `avutil.NewFrame`
- `avfilter.NewGraph`, `NewInOut`
- `avfilter.Graph.Dump`, `DumpWithOptions`
- `avfilter.InOut.SetName`
- `avformat.NewContextForInput`
- `avformat.ProbeData.SetFileName`, `SetBuffer`, `SetMimeType`

### Kept errored

- `avutil.NewAudioFifo` — kept `(*AudioFifo, error)` for the real `nb_samples == 0` precondition error; only the OOM branch panics.
- `avfilter.Graph.AddFilter` and `avformat.Context.NewStream` — untouched. Both have real non-OOM failure modes (duplicate filter name, `max_streams` limit). They still return `ErrAllocationError`; renaming those to more specific errors is a follow-up.

### Downstream impact

This is a breaking API change. Companion updates needed in `synchroniser` (and any other consumer) — separate PRs.

## Test plan

- [x] `go build -tags=ffmpeg43 ./...` clean
- [x] `go test -vet=off -tags=ffmpeg43 -run '<changed funcs>' ./...` — green across `avcodec`, `avutil`, `avfilter`, `avformat`
- [x] `gofmt` clean on touched files
- [ ] Verify in `synchroniser` (separate PR)

Pre-existing failures unchanged by this PR: missing fixture files, `/bin/ps` sandboxing in leak tests, `TestGraphRequestOldest` SIGSEGV inside FFmpeg, and the `ExampleShowMediaInfo` vet error in `avformat_test.go`.