### PR TITLE
Add filter graph interfaces and libav.DefaultFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@
 - Fix interrupt callback: set opaque pointer before avformat_open_input so URLContext copy inherits it
 - Replace deprecated FFmpeg 4.3 APIs and remove the now-empty avcodec/avformat/avfilter RegisterAll wrappers
 - Panic on libav allocation failures
+- Add IContext/IGraph/IDictionary interfaces and libav.AVFactory for testability; Graph.AddFilter / Context.Link / Context.InitWithDictionary now take interface parameters (source-compatible for callers passing concrete types)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,4 @@
 - Fix interrupt callback: set opaque pointer before avformat_open_input so URLContext copy inherits it
 - Replace deprecated FFmpeg 4.3 APIs and remove the now-empty avcodec/avformat/avfilter RegisterAll wrappers
 - Panic on libav allocation failures
-- Add IContext/IGraph/IDictionary interfaces and libav.AVFactory for testability; Graph.AddFilter / Context.Link / Context.InitWithDictionary now take interface parameters (source-compatible for callers passing concrete types)
+- Add libav factory + filter graph interfaces

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -264,9 +264,6 @@ func (ctx *Context) InitWithString(args string) error {
 	return nil
 }
 
-// InitWithDictionary accepts an avutil.IDictionary so tests can substitute
-// fakes. The production *avutil.Dictionary satisfies the interface; any other
-// implementation yields an error.
 func (ctx *Context) InitWithDictionary(options avutil.IDictionary) error {
 	var cOptions **C.AVDictionary
 	if options != nil {
@@ -283,8 +280,6 @@ func (ctx *Context) InitWithDictionary(options avutil.IDictionary) error {
 	return nil
 }
 
-// Link accepts an IContext so tests can substitute fakes. The production
-// *Context satisfies the interface; any other implementation yields an error.
 func (ctx *Context) Link(srcPad uint, dst IContext, dstPad uint) error {
 	target, ok := dst.(*Context)
 	if !ok {
@@ -496,10 +491,6 @@ func (g *Graph) AddFilter(filter *Filter, name string) (*Context, error) {
 	return NewContextFromC(unsafe.Pointer(cCtx)), nil
 }
 
-// AddFilterByName looks up the named filter type and allocates an instance
-// with the given id inside the graph. Equivalent to FindFilterByName followed
-// by AddFilter, exposed on IGraph so callers can drive graph construction
-// through a single interface method.
 func (g *Graph) AddFilterByName(name, id string) (IContext, error) {
 	filter, err := FindFilterByName(name)
 	if err != nil {

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -264,10 +264,17 @@ func (ctx *Context) InitWithString(args string) error {
 	return nil
 }
 
-func (ctx *Context) InitWithDictionary(options *avutil.Dictionary) error {
+// InitWithDictionary accepts an avutil.IDictionary so tests can substitute
+// fakes. The production *avutil.Dictionary satisfies the interface; any other
+// implementation yields an error.
+func (ctx *Context) InitWithDictionary(options avutil.IDictionary) error {
 	var cOptions **C.AVDictionary
 	if options != nil {
-		cOptions = (**C.AVDictionary)(options.Pointer())
+		concrete, ok := options.(*avutil.Dictionary)
+		if !ok {
+			return errors.New("avfilter.Context.InitWithDictionary: opts must be *avutil.Dictionary")
+		}
+		cOptions = (**C.AVDictionary)(concrete.Pointer())
 	}
 	code := C.avfilter_init_dict(ctx.CAVFilterContext, cOptions)
 	if code < 0 {
@@ -276,10 +283,14 @@ func (ctx *Context) InitWithDictionary(options *avutil.Dictionary) error {
 	return nil
 }
 
-func (ctx *Context) Link(srcPad uint, dst *Context, dstPad uint) error {
-	cSrc := ctx.CAVFilterContext
-	cDst := dst.CAVFilterContext
-	code := C.avfilter_link(cSrc, C.uint(srcPad), cDst, C.uint(dstPad))
+// Link accepts an IContext so tests can substitute fakes. The production
+// *Context satisfies the interface; any other implementation yields an error.
+func (ctx *Context) Link(srcPad uint, dst IContext, dstPad uint) error {
+	target, ok := dst.(*Context)
+	if !ok {
+		return errors.New("avfilter.Context.Link: dst must be *avfilter.Context")
+	}
+	code := C.avfilter_link(ctx.CAVFilterContext, C.uint(srcPad), target.CAVFilterContext, C.uint(dstPad))
 	if code < 0 {
 		return avutil.NewErrorFromCode(avutil.ErrorCode(code))
 	}
@@ -475,8 +486,15 @@ func (g *Graph) NumberOfFilters() uint {
 	return uint(g.CAVFilterGraph.nb_filters)
 }
 
-func (g *Graph) AddFilter(filter *Filter, name string) (*Context, error) {
-	cName := C.CString(name)
+// AddFilter looks up the named filter type and allocates an instance with the
+// given id inside the graph. Bundles FindFilterByName + the underlying C call
+// so callers don't need to thread *Filter through their code.
+func (g *Graph) AddFilter(name, id string) (IContext, error) {
+	filter, err := FindFilterByName(name)
+	if err != nil {
+		return nil, err
+	}
+	cName := C.CString(id)
 	defer C.free(unsafe.Pointer(cName))
 	cCtx := C.avfilter_graph_alloc_filter(g.CAVFilterGraph, filter.CAVFilter, cName)
 	if cCtx == nil {

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -486,21 +486,26 @@ func (g *Graph) NumberOfFilters() uint {
 	return uint(g.CAVFilterGraph.nb_filters)
 }
 
-// AddFilter looks up the named filter type and allocates an instance with the
-// given id inside the graph. Bundles FindFilterByName + the underlying C call
-// so callers don't need to thread *Filter through their code.
-func (g *Graph) AddFilter(name, id string) (IContext, error) {
-	filter, err := FindFilterByName(name)
-	if err != nil {
-		return nil, err
-	}
-	cName := C.CString(id)
+func (g *Graph) AddFilter(filter *Filter, name string) (*Context, error) {
+	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 	cCtx := C.avfilter_graph_alloc_filter(g.CAVFilterGraph, filter.CAVFilter, cName)
 	if cCtx == nil {
 		return nil, ErrAllocationError
 	}
 	return NewContextFromC(unsafe.Pointer(cCtx)), nil
+}
+
+// AddFilterByName looks up the named filter type and allocates an instance
+// with the given id inside the graph. Equivalent to FindFilterByName followed
+// by AddFilter, exposed on IGraph so callers can drive graph construction
+// through a single interface method.
+func (g *Graph) AddFilterByName(name, id string) (IContext, error) {
+	filter, err := FindFilterByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return g.AddFilter(filter, id)
 }
 
 func (g *Graph) Parse(filters string, input, output *InOut) error {

--- a/avfilter/avfilter_test.go
+++ b/avfilter/avfilter_test.go
@@ -117,16 +117,13 @@ func testFilterByName(t *testing.T, name string) *Filter {
 }
 
 func testGraphAddFilter(t *testing.T, graph *Graph, name, id string) *Context {
-	ictx, err := graph.AddFilter(name, id)
+	filter := testFilterByName(t, name)
+	ctx, err := graph.AddFilter(filter, id)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ictx == nil {
+	if ctx == nil {
 		t.Fatalf("Expecting filter context")
-	}
-	ctx, ok := ictx.(*Context)
-	if !ok {
-		t.Fatalf("Expecting *Context, got %T", ictx)
 	}
 	if !strings.EqualFold(id, ctx.Name()) {
 		t.Fatalf("[testAddFilter] context name expected: %s, got: %s", id, ctx.Name())

--- a/avfilter/avfilter_test.go
+++ b/avfilter/avfilter_test.go
@@ -117,13 +117,16 @@ func testFilterByName(t *testing.T, name string) *Filter {
 }
 
 func testGraphAddFilter(t *testing.T, graph *Graph, name, id string) *Context {
-	filter := testFilterByName(t, name)
-	ctx, err := graph.AddFilter(filter, id)
+	ictx, err := graph.AddFilter(name, id)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ctx == nil {
+	if ictx == nil {
 		t.Fatalf("Expecting filter context")
+	}
+	ctx, ok := ictx.(*Context)
+	if !ok {
+		t.Fatalf("Expecting *Context, got %T", ictx)
 	}
 	if !strings.EqualFold(id, ctx.Name()) {
 		t.Fatalf("[testAddFilter] context name expected: %s, got: %s", id, ctx.Name())

--- a/avfilter/interfaces.go
+++ b/avfilter/interfaces.go
@@ -6,7 +6,6 @@ import (
 	"github.com/SpalkLtd/go-libav/avutil"
 )
 
-// IContext is the interface implemented by *Context.
 type IContext interface {
 	Name() string
 	Init() error
@@ -23,7 +22,6 @@ type IContext interface {
 	GetFrame(frame *avutil.Frame) error
 }
 
-// IGraph is the interface implemented by *Graph.
 type IGraph interface {
 	AddFilterByName(name, id string) (IContext, error)
 	Config() error

--- a/avfilter/interfaces.go
+++ b/avfilter/interfaces.go
@@ -9,6 +9,7 @@ import (
 // IContext is the interface a filter context exposes for setup, linking, and
 // frame in/out. *Context implements it directly. Tests may substitute fakes.
 type IContext interface {
+	Name() string
 	Init() error
 	InitWithDictionary(opts avutil.IDictionary) error
 	Link(srcPad uint, dst IContext, dstPad uint) error
@@ -20,6 +21,7 @@ type IContext interface {
 	SetInt64OptionC(name unsafe.Pointer, val int64) error
 	AddFrameWithFlags(frame *avutil.Frame, flags BufferSrcFlags) error
 	GetFrameWithFlags(frame *avutil.Frame, flags BufferSinkFlags) error
+	GetFrame(frame *avutil.Frame) error
 }
 
 // IGraph is the interface a filter graph exposes for filter creation and

--- a/avfilter/interfaces.go
+++ b/avfilter/interfaces.go
@@ -1,0 +1,32 @@
+package avfilter
+
+import (
+	"unsafe"
+
+	"github.com/SpalkLtd/go-libav/avutil"
+)
+
+// IContext is the interface a filter context exposes for setup, linking, and
+// frame in/out. *Context implements it directly. Tests may substitute fakes.
+type IContext interface {
+	Init() error
+	InitWithDictionary(opts avutil.IDictionary) error
+	Link(srcPad uint, dst IContext, dstPad uint) error
+	SendCommand(cmd, args string, returnLength int) (string, error)
+	SetOption(name, value string) error
+	SetChannelLayoutOption(layout avutil.ChannelLayout) error
+	SetSampleFormatOption(name string, format avutil.SampleFormat) error
+	SetRationalOption(name string, val *avutil.Rational) error
+	SetInt64OptionC(name unsafe.Pointer, val int64) error
+	AddFrameWithFlags(frame *avutil.Frame, flags BufferSrcFlags) error
+	GetFrameWithFlags(frame *avutil.Frame, flags BufferSinkFlags) error
+}
+
+// IGraph is the interface a filter graph exposes for filter creation and
+// lifecycle. *Graph implements it directly.
+type IGraph interface {
+	AddFilter(name, id string) (IContext, error)
+	Config() error
+	RequestOldest() error
+	Free()
+}

--- a/avfilter/interfaces.go
+++ b/avfilter/interfaces.go
@@ -27,7 +27,7 @@ type IContext interface {
 // IGraph is the interface a filter graph exposes for filter creation and
 // lifecycle. *Graph implements it directly.
 type IGraph interface {
-	AddFilter(name, id string) (IContext, error)
+	AddFilterByName(name, id string) (IContext, error)
 	Config() error
 	RequestOldest() error
 	Free()

--- a/avfilter/interfaces.go
+++ b/avfilter/interfaces.go
@@ -6,8 +6,7 @@ import (
 	"github.com/SpalkLtd/go-libav/avutil"
 )
 
-// IContext is the interface a filter context exposes for setup, linking, and
-// frame in/out. *Context implements it directly. Tests may substitute fakes.
+// IContext is the interface implemented by *Context.
 type IContext interface {
 	Name() string
 	Init() error
@@ -24,8 +23,7 @@ type IContext interface {
 	GetFrame(frame *avutil.Frame) error
 }
 
-// IGraph is the interface a filter graph exposes for filter creation and
-// lifecycle. *Graph implements it directly.
+// IGraph is the interface implemented by *Graph.
 type IGraph interface {
 	AddFilterByName(name, id string) (IContext, error)
 	Config() error

--- a/avutil/interfaces.go
+++ b/avutil/interfaces.go
@@ -1,7 +1,6 @@
 package avutil
 
-// IDictionary is the interface a libav AVDictionary exposes. *Dictionary
-// implements it directly; tests may substitute fakes.
+// IDictionary is the interface implemented by *Dictionary.
 type IDictionary interface {
 	Set(key, value string) error
 	Free()

--- a/avutil/interfaces.go
+++ b/avutil/interfaces.go
@@ -1,0 +1,8 @@
+package avutil
+
+// IDictionary is the interface a libav AVDictionary exposes. *Dictionary
+// implements it directly; tests may substitute fakes.
+type IDictionary interface {
+	Set(key, value string) error
+	Free()
+}

--- a/avutil/interfaces.go
+++ b/avutil/interfaces.go
@@ -1,6 +1,5 @@
 package avutil
 
-// IDictionary is the interface implemented by *Dictionary.
 type IDictionary interface {
 	Set(key, value string) error
 	Free()

--- a/libav/factory.go
+++ b/libav/factory.go
@@ -1,0 +1,25 @@
+// Package libav exposes a cross-cutting AVFactory interface that bundles the
+// libav constructors most users need: filter graphs and option dictionaries.
+//
+// The default factory wraps the real libav constructors. Tests substitute fakes
+// to drive error paths without calling into FFmpeg.
+package libav
+
+import (
+	"github.com/SpalkLtd/go-libav/avfilter"
+	"github.com/SpalkLtd/go-libav/avutil"
+)
+
+// AVFactory creates the libav primitives used by code that builds filter graphs.
+type AVFactory interface {
+	NewGraph() avfilter.IGraph
+	NewDictionary() avutil.IDictionary
+}
+
+// DefaultFactory returns an AVFactory that wraps the real libav constructors.
+func DefaultFactory() AVFactory { return defaultFactory{} }
+
+type defaultFactory struct{}
+
+func (defaultFactory) NewGraph() avfilter.IGraph        { return avfilter.NewGraph() }
+func (defaultFactory) NewDictionary() avutil.IDictionary { return avutil.NewDictionary() }

--- a/libav/factory.go
+++ b/libav/factory.go
@@ -5,12 +5,8 @@ import (
 	"github.com/SpalkLtd/go-libav/avutil"
 )
 
-// DefaultFactory returns a value whose NewGraph and NewDictionary methods wrap
-// avfilter.NewGraph and avutil.NewDictionary. Consumers define their own
-// factory interface and accept this value through it.
 func DefaultFactory() Factory { return Factory{} }
 
-// Factory is the concrete type returned by DefaultFactory.
 type Factory struct{}
 
 func (Factory) NewGraph() avfilter.IGraph        { return avfilter.NewGraph() }

--- a/libav/factory.go
+++ b/libav/factory.go
@@ -1,8 +1,3 @@
-// Package libav exposes a cross-cutting AVFactory interface that bundles the
-// libav constructors most users need: filter graphs and option dictionaries.
-//
-// The default factory wraps the real libav constructors. Tests substitute fakes
-// to drive error paths without calling into FFmpeg.
 package libav
 
 import (
@@ -10,16 +5,13 @@ import (
 	"github.com/SpalkLtd/go-libav/avutil"
 )
 
-// AVFactory creates the libav primitives used by code that builds filter graphs.
-type AVFactory interface {
-	NewGraph() avfilter.IGraph
-	NewDictionary() avutil.IDictionary
-}
+// DefaultFactory returns a value whose NewGraph and NewDictionary methods wrap
+// avfilter.NewGraph and avutil.NewDictionary. Consumers define their own
+// factory interface and accept this value through it.
+func DefaultFactory() Factory { return Factory{} }
 
-// DefaultFactory returns an AVFactory that wraps the real libav constructors.
-func DefaultFactory() AVFactory { return defaultFactory{} }
+// Factory is the concrete type returned by DefaultFactory.
+type Factory struct{}
 
-type defaultFactory struct{}
-
-func (defaultFactory) NewGraph() avfilter.IGraph        { return avfilter.NewGraph() }
-func (defaultFactory) NewDictionary() avutil.IDictionary { return avutil.NewDictionary() }
+func (Factory) NewGraph() avfilter.IGraph        { return avfilter.NewGraph() }
+func (Factory) NewDictionary() avutil.IDictionary { return avutil.NewDictionary() }


### PR DESCRIPTION
# Summary

Adds interfaces so consumers can substitute fakes for the libav primitives that drive filter graphs. `*Context`, `*Graph`, and `*Dictionary` implement the new interfaces natively — consumers don't need to wrap them.

Companion PR (synchroniser): https://github.com/SpalkLtd/synchroniser/pull/1851

# Changes

**New interfaces** (in dedicated `interfaces.go` files per package):
- `avfilter.IContext` — Init, InitWithDictionary, Link, SendCommand, SetOption, the typed SetXxxOption helpers, AddFrameWithFlags, GetFrameWithFlags, GetFrame, Name.
- `avfilter.IGraph` — AddFilterByName, Config, RequestOldest, Free.
- `avutil.IDictionary` — Set, Free.

**New package** `github.com/SpalkLtd/go-libav/libav`:
- `libav.DefaultFactory()` returns a concrete `libav.Factory` struct with `NewGraph()` and `NewDictionary()` methods. No interface declared here — consumers define a factory interface in their own package and accept this concrete value through it.

**Signature changes** (source-compatible — concrete types still satisfy the new interface parameters):
- `(*Context).Link(srcPad, dst, dstPad)` — `dst` is now `IContext`, type-asserted internally.
- `(*Context).InitWithDictionary(opts)` — `opts` is now `avutil.IDictionary`, type-asserted internally.

**Additions** (no breaking changes):
- `(*Graph).AddFilterByName(name, id string) (IContext, error)` bundles `FindFilterByName` + `AddFilter`. The existing `(*Graph).AddFilter(filter *Filter, name string)` is unchanged.

# Test plan
- [x] `go build -tags=ffmpeg43 ./...` — passes
- [x] `go vet -tags=ffmpeg43 ./avfilter ./avutil ./libav` — clean
- [ ] Full `go test` requires patched spalk-ffmpeg dev libraries; runs in CI

# Risk

Source-compatible for all existing callers — every place that calls `Link` or `InitWithDictionary` passes a concrete `*Context` / `*Dictionary`, which still satisfies the new interface parameter types. No `(*Graph).AddFilter` callers need to change.